### PR TITLE
Bug fix/double wallet read only

### DIFF
--- a/src/components/MainContent.jsx
+++ b/src/components/MainContent.jsx
@@ -34,15 +34,19 @@ const MainContent = ({ state, setState, openModal, isConnecting }) => {
   };
   return (
     <Main>
-      <Row>
-        <Col>
-          <Wallet
-            theme={state.theme}
-            address={state.address}
-            provider={state.provider}
-          />
-        </Col>
-      </Row>
+      {isCheckingBalance ? (
+        ""
+      ) : (
+        <Row>
+          <Col>
+            <Wallet
+              theme={state.theme}
+              address={state.address}
+              provider={state.provider}
+            />
+          </Col>
+        </Row>
+      )}
       <div className="farm-info">
         <Balance state={state} />
         <APY apy={state.apy} display={state.display} theme={state.theme} />

--- a/src/components/checkBalance/CheckBalance.jsx
+++ b/src/components/checkBalance/CheckBalance.jsx
@@ -81,8 +81,8 @@ const CheckBalance = (props) => {
   };
 
   const setCheck = (address) => {
-    setState({ ...state, address: addressToCheck });
     if (address && validateAddress(address)) {
+      setState({ ...state, address: addressToCheck });
       setCheckingBalance(true);
       checkBalances(address);
     } else {

--- a/src/components/checkBalance/CheckBalance.jsx
+++ b/src/components/checkBalance/CheckBalance.jsx
@@ -81,6 +81,7 @@ const CheckBalance = (props) => {
   };
 
   const setCheck = (address) => {
+    setState({ ...state, address: addressToCheck });
     if (address && validateAddress(address)) {
       setCheckingBalance(true);
       checkBalances(address);

--- a/src/components/totalFarmEarned/TotalFarmEarned.jsx
+++ b/src/components/totalFarmEarned/TotalFarmEarned.jsx
@@ -12,7 +12,7 @@ const TotalFarmEarned = () => {
     <ThemeProvider theme={state.theme === "dark" ? darkTheme : lightTheme}>
       {state.display ? (
         <BluePanel>
-          <h1>{state.totalFarmEarned.toFixed(6)}</h1>
+          <h1>{state.totalFarmEarned?.toFixed(6)}</h1>
           <span>Farm Earned</span>
         </BluePanel>
       ) : (


### PR DESCRIPTION
Fixes double wallets showing and adds a check to prevent throwing an error if totalFarmEarned is not yet loaded.