### PR TITLE
fix z-index of radio

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -241,7 +241,7 @@ const Panel = styled.div`
   //Radio Modal
   .flexible-modal {
     position: absolute;
-    z-index: 1;
+    z-index: 51;
     background-color: #ddd;
     height: 2rem;
     border: 1px solid black;


### PR DESCRIPTION
Fix issue in https://github.com/harvestfi/dashboard/issues/41 by changing z-index of radio so that it appears over all of the other content in read-only mode